### PR TITLE
Fix Header On Mobiles

### DIFF
--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -220,7 +220,7 @@ export function SolidarityActionsTimeline ({
               <h3 className='text-xs text-left left-0 w-full font-mono uppercase mb-2'>
                 Filter by
               </h3>
-              <div className='relative space-x-2 flex flex-wrap'>
+              <div className='relative flex flex-wrap gap-2'>
                 <div>
                   <Listbox value={filteredCountrySlugs[0]} onChange={v => setCountries([v])}>
                     <Listbox.Button>

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -220,7 +220,7 @@ export function SolidarityActionsTimeline ({
               <h3 className='text-xs text-left left-0 w-full font-mono uppercase mb-2'>
                 Filter by
               </h3>
-              <div className='relative space-x-2 flex'>
+              <div className='relative space-x-2 flex flex-wrap'>
                 <div>
                   <Listbox value={filteredCountrySlugs[0]} onChange={v => setCountries([v])}>
                     <Listbox.Button>


### PR DESCRIPTION
After an immense amount of messing about, this filter is the cause of the header being wrong on phones.

The filters pushed the whole content out. The header responded correctly according to their placement in the CSS grid, but the filter was pushing out causing extra width broadly. Was led astray by the red herring of this being about the header at all, when it was about the filters all along.