### PR TITLE
Fix scrolling to year

### DIFF
--- a/components/ActionChart.tsx
+++ b/components/ActionChart.tsx
@@ -1,26 +1,17 @@
+import { ParentSize } from '@visx/responsive';
 import {
   Axis,
-  AreaSeries,
-  BarSeries,
-  XYChart,
-  Tooltip,
-  GlyphSeries,
-  ThemeContext
+  BarSeries, ThemeContext, XYChart
 } from '@visx/xychart';
-import { ParentSize } from '@visx/responsive';
-import { SolidarityAction } from '../data/types';
-import { bin, extent, HistogramGeneratorNumber } from "d3-array"
-import { scaleTime } from "d3-scale"
-import useSWR from 'swr';
-import { SolidarityActionsData } from '../pages/api/solidarityActions';
-import { min, max, format } from 'date-fns';
+import { bin, HistogramGeneratorNumber } from "d3-array";
 import { timeMonth, timeMonths, timeYears } from 'd3-time';
-import pluralize from 'pluralize';
-import tw, { theme } from 'twin.macro'
 import { timeFormat } from 'd3-time-format';
+import { min } from 'date-fns';
+import { useMemo } from 'react';
+import { theme } from 'twin.macro';
+import { SolidarityAction } from '../data/types';
 import { useMediaQuery } from '../utils/mediaQuery';
 import { up } from '../utils/screens';
-import { useMemo } from 'react';
 
 export function CumulativeMovementChart ({ data, onSelectYear }: { data: SolidarityAction[], cumulative?: boolean, onSelectYear?: (year: string) => void }) {
   const actionDates = data.map(d => new Date(d.fields.Date))

--- a/components/ActionChart.tsx
+++ b/components/ActionChart.tsx
@@ -66,7 +66,6 @@ export function CumulativeChart ({
   onSelectYear?: (year: string) => void
 }) {
   var yearBins = timeYears(timeMonth.offset(minDate, -1), timeMonth.offset(maxDate, 1));
-  var monthBins = timeMonths(timeMonth.offset(minDate, -1), timeMonth.offset(maxDate, 1));
 
   const createBinFn = (dateBins: Date[]) => {
     return  bin<SolidarityAction, Date>()

--- a/components/ActionChart.tsx
+++ b/components/ActionChart.tsx
@@ -31,19 +31,6 @@ export function CumulativeMovementChart ({ data, onSelectYear }: { data: Solidar
     <div className='relative cursor-pointer action-chart' style={{ height: 120, maxHeight: '25vh' }}>
       <ParentSize>{(parent) => (
         <>
-          {/* <h3 className='text-xs text-left absolute top-0 left-0 w-full font-mono uppercase'>
-            Solidarity actions / year
-          </h3> */}
-          {/* <div className='text-xs'>
-            <div className='space-x-1'>
-              <span className='align-middle inline-block w-3 h-3 bg-gwOrangeLight' />
-              <span className='align-middle'>Growth</span>
-            </div>
-            <div className='space-x-1'>
-              <span className='align-middle inline-block w-3 h-3 bg-gwPink' />
-              <span className='align-middle'>Frequency</span>
-            </div>
-          </div> */}
           <CumulativeChart
             data={data}
             minDate={minDate}
@@ -99,14 +86,6 @@ export function CumulativeChart ({
 
   const yearBinFn = createBinFn(yearBins)
 
-  // const cumulativeBinnedData = useMemo(() => {
-  //   let d = yearBinFn(data)
-  //   for(var i = 0; i < d.length; i++) {
-  //     d[i]['y'] = d[i].length + (d?.[i-1]?.['y'] || 0)
-  //   }
-  //   return d
-  // }, [data])
-
   const binnedData = useMemo(() => {
     let d = yearBinFn(data)
     for(var i = 0; i < d.length; i++) {
@@ -114,14 +93,6 @@ export function CumulativeChart ({
     }
     return d
   }, [data])
-
-  // const monthlyBinnedData = useMemo(() => {
-  //   let d = createBinFn(monthBins)(data)
-  //   for(var i = 0; i < d.length; i++) {
-  //     d[i]['y'] = d[i].length || 0
-  //   }
-  //   return d
-  // }, [data])
 
   const isSmallScreen = !useMediaQuery(up('xl'))
 
@@ -134,14 +105,10 @@ export function CumulativeChart ({
           // @ts-ignore
           bottom: {
             axisLine: {
-              // className: 'stroke-current text-gray-400',
               stroke: theme`colors.gray.400`
             },
             tickLine: {
-              // stroke: theme`colors.gray.400`,
-              // opacity: 0,
               stroke: 'transparent'
-              // y2: 0
             },
             tickLabel: {
               className: 'font-mono fill-current text-gray-400 text-xs',
@@ -159,24 +126,6 @@ export function CumulativeChart ({
         yScale={{ type: 'linear' }}
         margin={{ left: 0, right: 0, bottom: 50, top: 0 }}
       >
-      {/* <AreaSeries
-        dataKey="Cumulative"
-        data={cumulativeBinnedData as any} {...accessors}
-        // renderLine={true}
-        // lineProps={{
-        //   stroke: theme`colors.gwOrange`,
-        //   strokeWidth: 2
-        // }}
-      /> */}
-      {/* <GlyphSeries
-        dataKey="Cumulative"
-        data={cumulativeBinnedData as any} {...accessors}
-        renderGlyph={(props, context) => {
-          return (
-            <circle fill={theme`colors.gwOrange`} cx={10} cy={props.y} cx={props.x} r={1.5} />
-          )
-        }}
-      /> */}
       <BarSeries
         dataKey="Frequency"
         data={binnedData as any} {...accessors}
@@ -184,23 +133,6 @@ export function CumulativeChart ({
           onSelectYear?.(timeFormat('%Y')(accessors.xAccessor(e.datum)))
         }}
       />
-      {/* <BarSeries
-        dataKey="FrequencyMonth"
-        data={monthlyBinnedData as any} {...accessors}
-      /> */}
-      {/* <GlyphSeries
-        dataKey="Frequency"
-        data={binnedData as any} {...accessors}
-        renderGlyph={(props, context) => {
-          return props.datum['y'] > 0 ? (
-            <text x={props.x} y={props.y - 3}
-              dominantBaseline="bottom" textAnchor="middle"
-              className='fill-current text-green-500 font-bold text-xs font-mono'>
-              +{props.datum['y']}
-            </text>
-          ) : null
-        }}
-      /> */}
       <Axis
         orientation="bottom"
         tickFormat={timeFormat(isSmallScreen ? "%y" : "%Y")}

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -10,7 +10,6 @@ import 'mapbox-gl/dist/mapbox-gl.css';
 import { theme } from 'twin.macro';
 import * as polished from 'polished'
 import router, { useRouter } from 'next/dist/client/router';
-import { scrollToId } from '../utils/router';
 import { FilterContext } from './Timeline';
 import { scaleLinear, scalePow } from 'd3-scale';
 import { max, median, min } from 'd3-array';

--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -47,7 +47,7 @@ function Header ({  }: {  }) {
         </div>
       </div>
     </header>
-    <nav className='top-0 sticky z-40 py-3 bg-gwPink' id='sticky-header' style={{opacity: '0.5'}}>
+    <nav className='top-0 sticky z-40 py-3 bg-gwPink' id='sticky-header'>
       <div className='text-sm md:text-base content-wrapper w-full flex flex-row flex-wrap justify-start -mx-1 space-x-1 md:-mx-2 md:space-x-3 items-center'>
         {data?.headerLinks?.map?.((link, i) => (
           <a

--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -47,7 +47,7 @@ function Header ({  }: {  }) {
         </div>
       </div>
     </header>
-    <nav className='top-0 sticky z-40 py-3 bg-gwPink' id='sticky-header'>
+    <nav className='top-0 sticky z-40 py-3 bg-gwPink' id='sticky-header' style={{opacity: '0.5'}}>
       <div className='text-sm md:text-base content-wrapper w-full flex flex-row flex-wrap justify-start -mx-1 space-x-1 md:-mx-2 md:space-x-3 items-center'>
         {data?.headerLinks?.map?.((link, i) => (
           <a

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -17,7 +17,7 @@ import { useContextualRouting } from 'next-use-contextual-routing';
 import { OrganisingGroupCard, OrganisingGroupDialog, useSelectedOrganisingGroup } from '../components/OrganisingGroup';
 import { UnionsByCountryData } from '../pages/api/organisingGroupsByCountry';
 import { ChevronRightIcon } from '@heroicons/react/outline';
-import { scrollToId } from '../utils/router';
+import { scrollToYear } from '../utils/router';
 import { groupUrl } from '../data/organisingGroup';
 import cx from 'classnames';
 import { groupBy } from 'lodash';

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-spring": "^9.2.3",
     "react-syntax-highlighter": "^15.4.3",
     "remove-markdown": "^0.3.0",
+    "scroll-into-view": "^1.16.0",
     "supercluster": "^7.1.3",
     "swr": "^0.5.6",
     "tailwindcss": "^2.2.4",

--- a/utils/router.ts
+++ b/utils/router.ts
@@ -4,10 +4,12 @@ import scrollIntoView from 'scroll-into-view';
 
 export function scrollToId(router: NextRouter, year: string) {
   const element = document.getElementById(year)
+  const header = document.getElementById('sticky-header')
 
   if (!element) return
-  
-  const headerHeight = 74
+  if (!header) return
+
+  const headerHeight = header.offsetHeight
   const headerScrollPadding = 8
   
   scrollIntoView(element, {

--- a/utils/router.ts
+++ b/utils/router.ts
@@ -7,7 +7,15 @@ export function scrollToId(router: NextRouter, year: string) {
 
   if (!element) return
   
-  scrollIntoView(element)
+  const headerHeight = 74
+  const headerScrollPadding = 20
+  
+  scrollIntoView(element, {
+    align:{
+      top: 0,
+      topOffset: headerHeight + headerScrollPadding
+    }
+  })
   
   // TODO: Re-add this functionality to update the hash
   // router.push({ hash: year }, undefined, { shallow: true, scroll: false })

--- a/utils/router.ts
+++ b/utils/router.ts
@@ -18,7 +18,4 @@ export function scrollToId(router: NextRouter, year: string) {
       topOffset: headerHeight + headerScrollPadding
     }
   })
-  
-  // TODO: Re-add this functionality to update the hash
-  // router.push({ hash: year }, undefined, { shallow: true, scroll: false })
 }

--- a/utils/router.ts
+++ b/utils/router.ts
@@ -1,20 +1,21 @@
-import { NextRouter } from "next/dist/client/router";
+import { NextRouter } from "next/dist/client/router"
 
 export function scrollToId(router: NextRouter, year: string) {
-  const element = document.getElementById(year);
-  if (!element) return
+  const element = document.getElementById(year)
 
-  if (!!element.scrollIntoView) {
-    // Smooth scroll to that elment
-    element.scrollIntoView({
-      behavior: 'smooth',
-      block: 'start',
-      inline: 'nearest',
-    });
-    setTimeout(() => {
-      router.push({ hash: year }, undefined, { shallow: true, scroll: false })
-    }, 450)
-  } else {
-    router.push({ hash: year }, undefined, { shallow: true, scroll: false })
-  }
+  if (!element) return
+  
+  // As we have a sticky header, we need to offset the smooth scrolling to it
+  // rather than use scrollTo
+  const headerOffset = 74
+  const elementPosition = element.getBoundingClientRect().top
+  const offsetPosition = elementPosition - headerOffset
+
+  window.scrollTo({
+    behavior: 'smooth',
+    top: offsetPosition
+  })
+
+  // TODO: Re-add this functionality to update the hash
+  // router.push({ hash: year }, undefined, { shallow: true, scroll: false })
 }

--- a/utils/router.ts
+++ b/utils/router.ts
@@ -2,7 +2,7 @@ import { NextRouter } from "next/dist/client/router"
 
 import scrollIntoView from 'scroll-into-view';
 
-export function scrollToId(router: NextRouter, year: string) {
+export function scrollToYear(router: NextRouter, year: string) {
   const element = document.getElementById(year)
   const header = document.getElementById('sticky-header')
 

--- a/utils/router.ts
+++ b/utils/router.ts
@@ -1,21 +1,14 @@
 import { NextRouter } from "next/dist/client/router"
 
+import scrollIntoView from 'scroll-into-view';
+
 export function scrollToId(router: NextRouter, year: string) {
   const element = document.getElementById(year)
 
   if (!element) return
   
-  // As we have a sticky header, we need to offset the smooth scrolling to it
-  // rather than use scrollTo
-  const headerOffset = 74
-  const elementPosition = element.getBoundingClientRect().top
-  const offsetPosition = elementPosition - headerOffset
-
-  window.scrollTo({
-    behavior: 'smooth',
-    top: offsetPosition
-  })
-
+  scrollIntoView(element)
+  
   // TODO: Re-add this functionality to update the hash
   // router.push({ hash: year }, undefined, { shallow: true, scroll: false })
 }

--- a/utils/router.ts
+++ b/utils/router.ts
@@ -8,7 +8,7 @@ export function scrollToId(router: NextRouter, year: string) {
   if (!element) return
   
   const headerHeight = 74
-  const headerScrollPadding = 20
+  const headerScrollPadding = 8
   
   scrollIntoView(element, {
     align:{

--- a/utils/router.ts
+++ b/utils/router.ts
@@ -1,6 +1,6 @@
 import { NextRouter } from "next/dist/client/router"
 
-import scrollIntoView from 'scroll-into-view';
+import scrollIntoView from 'scroll-into-view'
 
 export function scrollToYear(router: NextRouter, year: string) {
   const element = document.getElementById(year)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4634,6 +4634,11 @@ scheduler@^0.20.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+scroll-into-view@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/scroll-into-view/-/scroll-into-view-1.16.0.tgz#07141fc4ba8a14b898d2163d6167f3d84cb9b05b"
+  integrity sha512-N8T/4mKzQXMorcbMzNm+rOfy0lPmga3zl7SmUSHDryA6cqGVlzG9pePQCqHA/UPaJtC2KOJP/r93pHm9df+5/A==
+
 select@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"


### PR DESCRIPTION
Current scrolling to the year is right, but since we have added a sticky header, we scroll to something covered by the header.

This means we can no longer use `scrollIntoView` because while it is "in view" as far as the browser is concerned, it is under something else. 

`scrollIntoView` is no respecter of items overlapping in the z-index and handles sticky headers particularly badly.

This fixes it by adding a third party library that makes the calculation for us and moves the page to the right place, allowing for an offset and a bit of padding.

## Limitations

Regresses adding a hash to Next.js router for the moment. Telling Next.js not to scroll doesn't seem to work, which means that we get a double scroll, spoiling the whole effect.

Taken a ticket to fix this, as is non-critical that this is a feature compared to the visual element here.