### PR TITLE
If an action has a document, use that instead of the generic social thumbnail

### DIFF
--- a/components/SolidarityActions.tsx
+++ b/components/SolidarityActions.tsx
@@ -19,6 +19,7 @@ import { actionUrl } from '../data/solidarityAction';
 import { Attachment, Country, SolidarityAction } from '../data/types';
 import { usePrevious } from '../utils/state';
 import { DateTime } from './Date';
+import { defaultOGImageStack } from '../pages/_app';
 
 interface ListProps {
   data: SolidarityAction[],
@@ -379,7 +380,15 @@ export function SolidarityActionCard ({ data, withContext, contextProps }: CardP
         canonical={actionUrl(data)}
         openGraph={{
           title: seoTitle,
-          description: data.summary.plaintext
+          description: data.summary.plaintext,
+          images: data.fields.Document?.length
+            ? [
+              {
+                url: data.fields.Document[0].thumbnails.large.url,
+                alt: 'Game Worker Solidarity',
+              },
+              ...defaultOGImageStack
+            ] : defaultOGImageStack
         }}
       />
       <article className={cx('space-y-2px rounded-xl overflow-hidden')}>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,6 +11,13 @@ import { projectStrings } from '../data/site';
 import '../styles/globals.css';
 import { doNotFetch } from '../utils/swr';
 
+export const defaultOGImageStack = [
+  {
+    url: projectStrings.baseUrl + `/images/game-workers-share-card.png`,
+    alt: 'Game Worker Solidarity',
+  }
+]
+
 function MyApp({ Component, pageProps, headerLinks, footerLinks }) {
   const canonicalURL = useCanonicalURL()
 
@@ -56,12 +63,7 @@ function MyApp({ Component, pageProps, headerLinks, footerLinks }) {
           site_name: projectStrings.name,
           title: projectStrings.name,
           description: projectStrings.description,
-          images: [
-            {
-              url: projectStrings.baseUrl + `/images/game-workers-share-card.png`,
-              alt: 'Game Worker Solidarity',
-            }
-          ]
+          images: defaultOGImageStack
         }}
         twitter={{
           handle: projectStrings.twitterHandle,


### PR DESCRIPTION
Simply uses the action's file thumbnail in place of the default social share image, if one is available. Not tested this yet!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've checked the spec (e.g. Figma file) and documented any divergences.
- [X] My code follows the code style of this project.