### PR TITLE
Live previews loading

### DIFF
--- a/pages/action/[actionId].tsx
+++ b/pages/action/[actionId].tsx
@@ -8,12 +8,19 @@ import ErrorPage from '../404'
 import PageLayout from '../../components/PageLayout';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
+import LoadingPage from '../../components/LoadingPage';
 
 type PageProps = { action: SolidarityAction | null, errorMessage?: string }
 type PageParams = { actionId: string, page?: string }
 
 export default function Page({ action, errorMessage }: PageProps) {
   const router = useRouter()
+  
+  // Show loading state while page is being generated
+  if (router.isFallback) {
+    return <LoadingPage />
+  }
+  
   if (!action) return <ErrorPage message={errorMessage} />
   useEffect(() => {
     // The user may have landed on the Airtable ID url rather than the canonical slugified URL

--- a/pages/group/[groupId].tsx
+++ b/pages/group/[groupId].tsx
@@ -8,12 +8,19 @@ import PageLayout from '../../components/PageLayout';
 import { OrganisingGroupCard, OrganisingGroupSEO } from '../../components/OrganisingGroup';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+import LoadingPage from '../../components/LoadingPage';
 
 type PageProps = { group: OrganisingGroup | null, errorMessage?: string }
 type PageParams = { groupId: string }
 
 export default function Page({ group, errorMessage }: PageProps) {
   const router = useRouter()
+  
+  // Show loading state while page is being generated
+  if (router.isFallback) {
+    return <LoadingPage />
+  }
+  
   if (!group) return <ErrorPage message={errorMessage} />
   useEffect(() => {
     // The user may have landed on the Airtable ID url rather than the canonical slugified URL


### PR DESCRIPTION
Add loading states to action and group pages to properly handle `fallback: true` during static generation.

The `[actionId].tsx` and `[groupId].tsx` pages use `fallback: true` in `getStaticPaths`, but previously did not display a loading indicator (`router.isFallback`) while pages were being generated on-demand. This change ensures users see a `LoadingPage` component during this process.

---
Linear Issue: [WIKI-83](https://linear.app/commonknowledge/issue/WIKI-83/make-sure-that-live-previews-are-loading)

<a href="https://cursor.com/background-agent?bcId=bc-1e960ce1-64d7-46c1-9244-833a83c43430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e960ce1-64d7-46c1-9244-833a83c43430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

