### PR TITLE
Timeline labels cross-browser display

### DIFF
--- a/components/SolidarityActions.tsx
+++ b/components/SolidarityActions.tsx
@@ -225,7 +225,7 @@ export function SolidarityActionsList({
                 </div>
               </div>
               {(hasHiddenActions && hiddenActionsOpen === false) && (
-                <button className="p-3 mt-3 font-semibold text-sm flex items-center" onClick={() => setOpenYears(openYears.concat(openYears, [yearString]))}>
+                <button className="p-3 mt-3 font-semibold text-sm flex items-center text-black" onClick={() => setOpenYears(openYears.concat(openYears, [yearString]))}>
                   <>
                     <span className="pr-1">Load {hiddenActions.length} more {pluralActionsCopy}</span>
                     {DownArrow}
@@ -233,7 +233,7 @@ export function SolidarityActionsList({
                 </button>
               )}
               {(hasHiddenActions && hiddenActionsOpen) && (
-                <button className="p-3 mt-3 font-semibold text-sm flex items-center" onClick={() => setOpenYears(openYears.filter(openYear => openYear !== yearString))}>
+                <button className="p-3 mt-3 font-semibold text-sm flex items-center text-black" onClick={() => setOpenYears(openYears.filter(openYear => openYear !== yearString))}>
                   <>
                     <span className="pr-1">Hide {hiddenActions.length} {pluralActionsCopy}</span>
                     {UpArrow}

--- a/components/SolidarityActions.tsx
+++ b/components/SolidarityActions.tsx
@@ -188,11 +188,11 @@ export function SolidarityActionsList({
             <div key={i}>
               <div className='flex flex-row justify-between items-center pb-3'>
                 <h2
-                  className={cx(mini ? 'text-lg' : 'text-2xl', 'font-semibold')}
+                  className={cx(mini ? 'text-lg' : 'text-2xl', 'font-semibold', 'text-black')}
                   id={yearString}>
                   {yearString}
                 </h2>
-                <div className='text-xs font-semibold'>
+                <div className='text-xs font-semibold text-black'>
                   {pluralize('action', actions.length, true)}
                 </div>
               </div>

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -262,7 +262,7 @@ export function SolidarityActionsTimeline ({
           <div className='p-4 lg:p-5 xl:pl-7 flex flex-col flex-nowrap md:h-screen sticky top-5 space-y-4'>
             <section className='flex-grow-0'>
               <div className='flex flex-wrap w-full justify-between text-sm'>
-                <h3 className='text-base text-left left-0 font-semibold mb-2'>
+                <h3 className='text-base text-left left-0 font-semibold mb-2 text-black'>
                   Filter by
                 </h3>
                 {hasFilters ? (
@@ -470,7 +470,7 @@ export function SolidarityActionsTimeline ({
               }} />
             </section>
             <section className='pt-1 flex-grow-0'>
-              <h3 className='text-base text-left w-full font-semibold'>
+              <h3 className='text-base text-left w-full font-semibold text-black'>
                 Select year
               </h3>
               <CumulativeMovementChart data={filteredActions} onSelectYear={year => scrollToYear(router, year)} />


### PR DESCRIPTION
Add explicit `text-black` to timeline labels and buttons to fix display issues in Firefox/Safari caused by inconsistent text color inheritance.

---
Linear Issue: [WIKI-85](https://linear.app/commonknowledge/issue/WIKI-85/fix-timeline-labels-not-appearing-on-timeline-on-firefoxsafari)

<a href="https://cursor.com/background-agent?bcId=bc-abcf7bf1-1a40-45ef-9eca-71879ab1800e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-abcf7bf1-1a40-45ef-9eca-71879ab1800e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

