### PR TITLE
All campaigns link

### DIFF
--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -7,6 +7,7 @@ type Links = Array<{ url: string, label: string }>
 
 const headerLinks: Links = [
   // All header links as JSON objects
+  { url: '/', label: 'All Campaigns' },
   { url: '/analysis', label: 'Analysis' },
   { url: '/start-organising', label: 'Organise!' },
   { url: '/submit', label: 'Submit Action' },
@@ -16,6 +17,7 @@ const headerLinks: Links = [
 
 const footerLinks: Links = [
   // All footer links as JSON objects
+  { url: '/', label: 'All Campaigns' },
   { url: '/analysis', label: 'Analysis' },
   { url: '/start-organising', label: 'Organise!' },
   { url: '/submit', label: 'Submit Action' },


### PR DESCRIPTION
Add an "All Campaigns" link to the header and footer navigation to improve site navigation and allow users to easily return to the full list of campaigns.

---
Linear Issue: [WIKI-100](https://linear.app/commonknowledge/issue/WIKI-100/all-campaigns-link)

<a href="https://cursor.com/background-agent?bcId=bc-dca856a3-e582-4164-bcff-b9c1b76ea260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dca856a3-e582-4164-bcff-b9c1b76ea260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

