### PR TITLE
Campaign article summaries

### DIFF
--- a/data/airtableValidation.ts
+++ b/data/airtableValidation.ts
@@ -3,5 +3,16 @@ import { SolidarityActionAirtableRecord } from './types';
 const lowercaseAlphanumericSlugRegex = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/
 
 export function validateAirtableAction (action: SolidarityActionAirtableRecord): boolean {
-  return !!action.fields.slug?.match(lowercaseAlphanumericSlugRegex)
+  // Validate slug format
+  const hasValidSlug = !!action.fields.slug?.match(lowercaseAlphanumericSlugRegex)
+  
+  // Validate required fields for SEO
+  const hasRequiredFields = !!(
+    action.fields.Name &&
+    action.fields.Date &&
+    action.fields.Summary && 
+    action.fields.Summary.trim().length > 0
+  )
+  
+  return hasValidSlug && hasRequiredFields
 }

--- a/data/solidarityAction.ts
+++ b/data/solidarityAction.ts
@@ -116,6 +116,7 @@ export async function getLiveSolidarityActions ({ filterByFormula, ...selectArgs
       'Public',
       'Name!=""',
       'Date!=""',
+      'Summary!=""',
       filterByFormula
     ),
     fields: fields,


### PR DESCRIPTION
Make the `Summary` field required for Solidarity Actions to ensure proper SEO and social media preview card display, aligning with existing requirements for Articles.

---
Linear Issue: [WIKI-89](https://linear.app/commonknowledge/issue/WIKI-89/campaign-and-articles-short-summary-for-seo-preview-card)

<a href="https://cursor.com/background-agent?bcId=bc-2ff32bae-17f6-4fe9-9190-fc7f34713e96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ff32bae-17f6-4fe9-9190-fc7f34713e96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

