### PR TITLE
Submission form consent box

### DIFF
--- a/src/app/(frontend)/submit-event/EventSubmissionForm.tsx
+++ b/src/app/(frontend)/submit-event/EventSubmissionForm.tsx
@@ -4,6 +4,7 @@ import { useState, FormEvent } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
 import { MultiSelect } from '@/components/MultiSelect'
 import type { Category, Country, Company, OrganisingGroup, Event } from '@/payload-types'
 import { EventInitiator } from '@/collections/enums'
@@ -32,12 +33,21 @@ export function EventSubmissionForm({
   const [selectedCountries, setSelectedCountries] = useState<string[]>([])
   const [selectedCompanies, setSelectedCompanies] = useState<string[]>([])
   const [selectedOrganisingGroups, setSelectedOrganisingGroups] = useState<string[]>([])
+  const [consent, setConsent] = useState(false)
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     setIsSubmitting(true)
     setSubmitStatus('idle')
     setErrorMessage('')
+
+    // Validate consent
+    if (!consent) {
+      setSubmitStatus('error')
+      setErrorMessage('You must consent to Game Worker Solidarity Project publishing this information')
+      setIsSubmitting(false)
+      return
+    }
 
     const formData = new FormData(e.currentTarget)
     const data: Omit<Event, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt' | 'slug'> = {
@@ -85,6 +95,7 @@ export function EventSubmissionForm({
       companies: selectedCompanies.length > 0 ? selectedCompanies : undefined,
       organisingGroups: selectedOrganisingGroups.length > 0 ? selectedOrganisingGroups : undefined,
       submissionContactDetails: formData.get('submissionContactDetails') as string,
+      consent: consent,
       _status: 'draft' as const,
     }
 
@@ -110,6 +121,7 @@ export function EventSubmissionForm({
       setSelectedCountries([])
       setSelectedCompanies([])
       setSelectedOrganisingGroups([])
+      setConsent(false)
     } catch (error: any) {
       setSubmitStatus('error')
       setErrorMessage(error.message || 'An error occurred while submitting the event')
@@ -315,6 +327,26 @@ export function EventSubmissionForm({
           <p className="text-sm text-gray-500 mt-1">
             We&apos;ll use this to contact you about your submission
           </p>
+        </div>
+      </section>
+
+      {/* Consent */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-bold">
+          Consent <span className="text-red-500">*</span>
+        </h2>
+
+        <div className="flex items-start space-x-3">
+          <Checkbox
+            id="consent"
+            checked={consent}
+            onCheckedChange={(checked) => setConsent(checked === true)}
+            className="mt-1"
+          />
+          <Label htmlFor="consent" className="cursor-pointer leading-relaxed">
+            I consent to Game Worker Solidarity Project publishing this information online and
+            offline
+          </Label>
         </div>
       </section>
 

--- a/src/collections/Events.ts
+++ b/src/collections/Events.ts
@@ -318,6 +318,15 @@ export const Events: CollectionConfig = {
         position: 'sidebar',
       },
     },
+    {
+      name: 'consent',
+      type: 'checkbox',
+      label: 'Consent',
+      admin: {
+        description: 'User consented to Game Worker Solidarity Project publishing this information online and offline',
+        position: 'sidebar',
+      },
+    },
   ],
   hooks: {
     beforeChange: [


### PR DESCRIPTION
Add a consent checkbox to the event submission form to capture user consent for publishing information, as required by WIKI-102.

---
Linear Issue: [WIKI-102](https://linear.app/commonknowledge/issue/WIKI-102/add-consent-box-to-submission-form)

<a href="https://cursor.com/background-agent?bcId=bc-205e62eb-3f38-4a51-b4a1-8c93f29f551d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-205e62eb-3f38-4a51-b4a1-8c93f29f551d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

