### PR TITLE
Fix for 'create' not working in admin dashboard (cache revalidation issue)

### DIFF
--- a/src/collections/Actions.ts
+++ b/src/collections/Actions.ts
@@ -14,6 +14,7 @@ import { revalidateCacheHook } from '@/lib/revalidate-on-change'
 import { convertLexicalToMarkdown, editorConfigFactory } from '@payloadcms/richtext-lexical'
 import { lexicalToPlainText } from '@/utils/lexicalToHTML'
 import { LexicalContent } from '@/global-types'
+import { after } from 'next/server'
 
 export const Actions: CollectionConfig = {
   slug: 'actions',
@@ -491,7 +492,11 @@ export const Actions: CollectionConfig = {
       },
     ],
     afterChange: [
-      revalidateCacheHook('actions'),
+      async () => {
+        after(() => {
+          revalidateCacheHook('actions')
+        })
+      },
       async ({ doc, operation, req }) => {
         // Send email notification when a new action is created as a draft
         if (operation === 'create' && doc._status === 'draft' && doc.submissionContactDetails) {

--- a/src/collections/Campaigns.ts
+++ b/src/collections/Campaigns.ts
@@ -5,6 +5,7 @@ import { Campaign } from '@/payload-types'
 import { TimelineLabelProperty } from '@/global-types'
 import { draftModeAccessControl } from '@/app/(payload)/querying/accessControl'
 import { revalidateCacheHook } from '@/lib/revalidate-on-change'
+import { after } from 'next/server'
 
 const highlightedActionAttributeOptions: Array<{ label: string; value: TimelineLabelProperty }> = [
   // Pick from companies, countries, categories, organising groups, headcount
@@ -213,7 +214,13 @@ export const Campaigns: CollectionConfig = {
     },
   ],
   hooks: {
-    afterChange: [revalidateCacheHook('campaigns')],
+    afterChange: [
+      async () => {
+        after(() => {
+          revalidateCacheHook('campaigns')
+        })
+      },
+    ],
     afterDelete: [revalidateCacheHook('campaigns')],
   },
 }

--- a/src/collections/Categories.ts
+++ b/src/collections/Categories.ts
@@ -4,6 +4,7 @@ import { getPath } from '@/utils/payloadPath'
 import { Category } from '@/payload-types'
 import { draftModeAccessControl } from '@/app/(payload)/querying/accessControl'
 import { revalidateCacheHook } from '@/lib/revalidate-on-change'
+import { after } from 'next/server'
 
 export const Categories: CollectionConfig = {
   slug: 'categories',
@@ -134,7 +135,13 @@ export const Categories: CollectionConfig = {
     },
   ],
   hooks: {
-    afterChange: [revalidateCacheHook('categories')],
+    afterChange: [
+      async () => {
+        after(() => {
+          revalidateCacheHook('categories')
+        })
+      },
+    ],
     afterDelete: [revalidateCacheHook('categories')],
   },
 }

--- a/src/collections/Companies.ts
+++ b/src/collections/Companies.ts
@@ -5,6 +5,7 @@ import { createBreadcrumbsField } from '@payloadcms/plugin-nested-docs'
 import { Company } from '@/payload-types'
 import { draftModeAccessControl } from '@/app/(payload)/querying/accessControl'
 import { revalidateCacheHook } from '@/lib/revalidate-on-change'
+import { after } from 'next/server'
 
 export const Companies: CollectionConfig = {
   slug: 'companies',
@@ -149,7 +150,13 @@ export const Companies: CollectionConfig = {
     },
   ],
   hooks: {
-    afterChange: [revalidateCacheHook('companies')],
+    afterChange: [
+      async () => {
+        after(() => {
+          revalidateCacheHook('companies')
+        })
+      },
+    ],
     afterDelete: [revalidateCacheHook('companies')],
   },
 }

--- a/src/collections/Countries.ts
+++ b/src/collections/Countries.ts
@@ -6,6 +6,7 @@ import { getPath } from '@/utils/payloadPath'
 import { Country } from '@/payload-types'
 import { draftModeAccessControl } from '@/app/(payload)/querying/accessControl'
 import { revalidateCacheHook } from '@/lib/revalidate-on-change'
+import { after } from 'next/server'
 
 export const Countries: CollectionConfig = {
   slug: 'countries',
@@ -199,7 +200,13 @@ export const Countries: CollectionConfig = {
     },
   ],
   hooks: {
-    afterChange: [revalidateCacheHook('countries')],
+    afterChange: [
+      async () => {
+        after(() => {
+          revalidateCacheHook('countries')
+        })
+      },
+    ],
     afterDelete: [revalidateCacheHook('countries')],
   },
 }

--- a/src/collections/OrganisingGroups.ts
+++ b/src/collections/OrganisingGroups.ts
@@ -5,6 +5,7 @@ import { createBreadcrumbsField } from '@payloadcms/plugin-nested-docs'
 import { OrganisingGroup } from '@/payload-types'
 import { draftModeAccessControl } from '@/app/(payload)/querying/accessControl'
 import { revalidateCacheHook } from '@/lib/revalidate-on-change'
+import { after } from 'next/server'
 
 export const OrganisingGroups: CollectionConfig = {
   slug: 'organisingGroups',
@@ -260,7 +261,13 @@ export const OrganisingGroups: CollectionConfig = {
     },
   ],
   hooks: {
-    afterChange: [revalidateCacheHook('organisingGroups')],
+    afterChange: [
+      async () => {
+        after(() => {
+          revalidateCacheHook('organisingGroups')
+        })
+      },
+    ],
     afterDelete: [revalidateCacheHook('organisingGroups')],
   },
 }


### PR DESCRIPTION
This change (hopefully!) fixes the following admin dashboard error that occurred when creating new Documents in the admin dashboard:

`ERROR: Route /admin/[[...segments]] used "revalidateTag homepage" during render which is unsupported. To ensure revalidation is performed consistently it must always happen outside of renders and cached functions. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`

This was caused by the `afterChange` hook being used to [revalidate the cache](https://nextjs.org/docs/app/guides/caching-without-cache-components) by calling `revalidateCacheHook` =>`revalidateTagsForCollection` => `revalidateTag` which should only ever be called outside renders, but in the case of 'create' was being called _during_ rendering.

Next JS v15.1.0 handily introduced [the after function](https://nextjs.org/docs/app/api-reference/functions/after) for just cases: it "allows you to schedule work to be executed after a response (or prerender) is finished" without us having to call an API route (which I notice we do have in the form of api/revalidate) ourselves, to ensure the revalidation happens at the right time.

Tested locally for all Collection types, including Actions:

![gws-revalidate-fix](https://github.com/user-attachments/assets/3c68912f-a2d1-4af0-ade9-b58c35bd2f8f)

Fair warning: this is my first time looking at a Next JS project, so hopefully this isn't doing something terribly silly!